### PR TITLE
feat: encode vars before serverless package

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ class EncodeEnvironmentVariables {
     this.hooks = {
       'before:offline:start': this.before.bind(this),
       'before:offline:start:init': this.before.bind(this),
+      'before:package:initialize': this.before.bind(this),
       'before:deploy:resources': this.before.bind(this),
       'before:encode:run': this.before.bind(this),
       'before:invoke:local:invoke': this.before.bind(this),


### PR DESCRIPTION
Encodes environment variables before the `serverless package` phase.